### PR TITLE
Add necessary package imports

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.cru</groupId>
         <artifactId>jersey-bundle</artifactId>
-        <version>1.0</version>
+        <version>1.1</version>
     </parent>
 
     <artifactId>jersey-bundle.core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -26,7 +26,19 @@
                         <Bundle-SymbolicName>cru-jersey-bundle</Bundle-SymbolicName>
                         <Bundle-Description>This bundle wraps the aopalliance dependency</Bundle-Description>
                         <Import-Package>
-                            <!-- Nothing -->
+                            javax.net.ssl;version=0.0.0,
+                            javax.xml.namespace;version=0.0.0,
+                            javax.xml.parsers;version=0.0.0,
+                            javax.xml.stream;version=1.0.0,
+                            javax.xml.transform;version=0.0.0,
+                            javax.xml.transform.dom;version=0.0.0,
+                            javax.xml.transform.sax;version=0.0.0,
+                            javax.xml.transform.stream;version=0.0.0,
+                            javax.activation,
+                            org.w3c.dom,
+                            org.xml.sax,
+                            org.xml.sax.ext,
+                            org.xml.sax.helpers
                         </Import-Package>
                         <Export-Package>
                             org.aopalliance.intercept,

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <groupId>org.cru</groupId>
   <artifactId>jersey-bundle</artifactId>
   <packaging>pom</packaging>
-  <version>1.0</version>
+  <version>1.1</version>
   <description>jersey-bundle</description>
 
   <modules>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.cru</groupId>
     <artifactId>jersey-bundle</artifactId>
-    <version>1.0</version>
+    <version>1.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
This PR adds some package imports required for calling out to an HTTPS web service (e.g. WSAPI). Adding them here prevents them from needing to be added in each bundle using this one.