### PR TITLE
Export jersey client

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,6 +34,7 @@
                             javax.xml.transform.dom;version=0.0.0,
                             javax.xml.transform.sax;version=0.0.0,
                             javax.xml.transform.stream;version=0.0.0,
+                            javax.xml.bind;version=0.0.0,
                             javax.activation,
                             org.w3c.dom,
                             org.xml.sax,
@@ -73,6 +74,11 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
         </dependency>
 
         <!-- HK2 Dependencies -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -44,7 +44,11 @@
                             javax.ws.rs,
                             javax.ws.rs.client,
                             javax.ws.rs.core,
-                            javax.ws.rs.ext
+                            javax.ws.rs.ext,
+                            org.glassfish.jersey.client,
+                            org.glassfish.jersey.client.authentication,
+                            org.glassfish.jersey.client.filter,
+                            org.glassfish.jersey.client.spi
                         </Export-Package>
                         <Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.cru</groupId>
         <artifactId>jersey-bundle</artifactId>
-        <version>1.2</version>
+        <version>1.2.1</version>
     </parent>
 
     <artifactId>jersey-bundle.core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <groupId>org.cru</groupId>
   <artifactId>jersey-bundle</artifactId>
   <packaging>pom</packaging>
-  <version>1.2</version>
+  <version>1.2.1</version>
   <description>jersey-bundle</description>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -489,6 +489,12 @@
         <version>${jersey.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.glassfish.jersey.core</groupId>
+        <artifactId>jersey-server</artifactId>
+        <version>${jersey.version}</version>
+      </dependency>
+
       <!-- HK2 Dependencies -->
       <dependency>
         <groupId>org.glassfish.hk2</groupId>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.cru</groupId>
     <artifactId>jersey-bundle</artifactId>
-    <version>1.2</version>
+    <version>1.2.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
This PR exports the jersey client packages for use by other projects (most notably `aem-authentication`).