### PR TITLE
Export Packages for Cloud

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -49,7 +49,9 @@
                             org.glassfish.jersey.client,
                             org.glassfish.jersey.client.authentication,
                             org.glassfish.jersey.client.filter,
-                            org.glassfish.jersey.client.spi
+                            org.glassfish.jersey.client.spi,
+                            org.glassfish.hk2.*,
+                            org.jvnet.hk2.component
                         </Export-Package>
                         <Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>


### PR DESCRIPTION
In the cloud we need to export these packages for `cru-aem-content-scoring`.