### PR TITLE
AEM-714 - Bump version to stay in line with all the other bundles

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.cru</groupId>
         <artifactId>jersey-bundle</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jersey-bundle.core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <artifactId>jersey-bundle</artifactId>
   <name>Jersey Bundle</name>
   <packaging>pom</packaging>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
   <description>jersey-bundle</description>
 
   <modules>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.cru</groupId>
     <artifactId>jersey-bundle</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
In order to keep parity between versions, all this PR does is bump from 3.0.0-SNAPSHOT to 4.0.0-SNAPSHOT. See https://github.com/CruGlobal/cru-aem-commons/pull/351 for details.